### PR TITLE
fix(tui): restore polished first-run hierarchy

### DIFF
--- a/src/tui-shell.ts
+++ b/src/tui-shell.ts
@@ -19,7 +19,7 @@ import { runAgent } from "./agent.js";
 import { runPalette } from "./palette.js";
 import type { PaletteCommand } from "./palette.js";
 import { redactHomePath, redactSecrets } from "./permission-impact.js";
-import { VERSION } from "./product-banner.js";
+import { MEDIUM_MARK, VERSION, WIDE_WORDMARK } from "./product-banner.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -28,7 +28,7 @@ import { VERSION } from "./product-banner.js";
 // Total composer band height (a state rule line plus bounded input rows).
 export const COMPOSER_MAX_ROWS = 8;
 export const COMPOSER_MIN_ROWS = 1;
-export const IDENTITY_MAX_ROWS = 1;
+export const IDENTITY_MAX_ROWS = 7;
 export const STATUS_ROWS = 1;
 
 // Minimum terminal dimensions before the full-screen shell is used at all; below
@@ -74,6 +74,9 @@ export interface StatusInfo {
 export interface ShellStyle {
   bold: string;
   dim: string;
+  accent: string;
+  accentSoft: string;
+  success: string;
   reset: string;
 }
 
@@ -121,8 +124,17 @@ export interface ComposedScreen {
 // ---------------------------------------------------------------------------
 
 export function shellStyle(color: boolean): ShellStyle {
-  if (!color) return { bold: "", dim: "", reset: "" };
-  return { bold: "\x1b[1m", dim: "\x1b[2m", reset: "\x1b[0m" };
+  if (!color) {
+    return { bold: "", dim: "", accent: "", accentSoft: "", success: "", reset: "" };
+  }
+  return {
+    bold: "\x1b[1m",
+    dim: "\x1b[2m",
+    accent: "\x1b[38;5;81m",
+    accentSoft: "\x1b[38;5;141m",
+    success: "\x1b[38;5;114m",
+    reset: "\x1b[0m",
+  };
 }
 
 function clamp(n: number, lo: number, hi: number): number {
@@ -185,8 +197,16 @@ export function computeLayout(viewport: Viewport, opts: { composerRows?: number 
   const statusRows = rows >= 1 ? STATUS_ROWS : 0;
   let remaining = rows - statusRows;
 
-  // Identity header: keep it only when there is comfortable room.
-  const identityRows = remaining >= 3 ? IDENTITY_MAX_ROWS : 0;
+  // Identity scales from a full product wordmark to a compact title. Decoration
+  // yields before conversation space on short or narrow terminals.
+  const identityRows =
+    remaining >= 17 && cols >= 44
+      ? IDENTITY_MAX_ROWS
+      : remaining >= 8 && cols >= 20
+        ? 2
+        : remaining >= 3
+          ? 1
+          : 0;
   remaining -= identityRows;
 
   // Composer: bounded, but always leave >= 1 row for the transcript when possible.
@@ -258,13 +278,22 @@ export function renderIdentity(layout: ShellLayout, style: ShellStyle, version: 
   const height = layout.identity.end - layout.identity.start;
   if (height <= 0) return [];
   const cols = layout.viewport.cols;
-  const wordmark = "OH MY CLI";
-  const ver = ` v${version}`;
-  // Clip on plain length so color escapes never inflate the visible width.
-  if (wordmark.length + ver.length > cols) {
-    return [clipLine(wordmark + ver, cols)];
+  const metadata = `v${version}  ·  terminal-native coding agent`;
+  if (height >= 7 && cols >= 44) {
+    const rows = WIDE_WORDMARK.map((line, index) => {
+      const tone = index < 2 ? style.accent : style.accentSoft;
+      return `${tone}${style.bold}${line}${style.reset}`;
+    });
+    return [...rows, `${style.dim}${clipLine(metadata, cols)}${style.reset}`, ""];
   }
-  return [`${style.bold}${wordmark}${style.reset}${style.dim}${ver}${style.reset}`];
+  if (height >= 2 && cols >= 20) {
+    const mark = MEDIUM_MARK[0] ?? "OMC";
+    return [
+      `${style.accent}${style.bold}${clipLine(mark, cols)}${style.reset}`,
+      `${style.dim}${clipLine(`OH MY CLI  ${metadata}`, cols)}${style.reset}`,
+    ];
+  }
+  return [`${style.accent}${style.bold}${clipLine(`OH MY CLI  v${version}`, cols)}${style.reset}`];
 }
 
 export function renderStatusLine(info: StatusInfo, layout: ShellLayout, style: ShellStyle): string[] {
@@ -275,11 +304,28 @@ export function renderStatusLine(info: StatusInfo, layout: ShellLayout, style: S
   // when known, and approval mode. No api key, base URL, or other credential.
   const parts = [
     info.model,
+    `approval ${info.approvalMode}`,
     info.workspace,
     info.contextUsage ? info.contextUsage : null,
-    `approval ${info.approvalMode}`,
   ].filter((p): p is string => Boolean(p));
-  return [`${style.dim}${clipLine(parts.join(" · "), cols)}${style.reset}`];
+  const indicator = `${style.success}●${style.reset}`;
+  return [`${indicator} ${style.dim}${clipLine(parts.join("  ·  "), Math.max(0, cols - 2))}${style.reset}`];
+}
+
+function renderEmptyTranscript(region: Region, cols: number, style: ShellStyle): string[] {
+  const height = Math.max(0, region.end - region.start);
+  if (height === 0) return [];
+  const content = [
+    `${style.accent}${style.bold}${clipLine("Ready for your next task", cols)}${style.reset}`,
+    `${style.dim}${clipLine("Ask a question, reference @files, or open commands with Ctrl+K.", cols)}${style.reset}`,
+    "",
+    `${style.dim}${clipLine("/help  explore capabilities    /status  inspect this session", cols)}${style.reset}`,
+  ];
+  const top = Math.max(1, Math.min(3, Math.floor((height - content.length) / 3)));
+  const lines = Array.from({ length: top }, () => "");
+  lines.push(...content.slice(0, Math.max(0, height - top)));
+  while (lines.length < height) lines.push("");
+  return lines.slice(0, height);
 }
 
 function entryPrefix(kind: TranscriptKind): string {
@@ -328,7 +374,7 @@ function renderRule(label: string, cols: number, style: ShellStyle): string {
   const labelCells = Array.from(label).length;
   if (cols <= labelCells) return clipLine(label, cols);
   const fill = cols - labelCells - 1;
-  return `${style.bold}${label}${style.reset} ${"─".repeat(fill)}`;
+  return `${style.accent}${style.bold}${label}${style.reset} ${style.dim}${"─".repeat(fill)}${style.reset}`;
 }
 
 // Render the composer band. When there is room (>= 2 rows) the first row is a
@@ -372,7 +418,10 @@ export function composeScreen(state: ShellState): ComposedScreen {
   const layout = computeLayout(state.viewport, { composerRows });
 
   const identityLines = renderIdentity(layout, style, state.version);
-  const transcriptLines = renderTranscript(state.transcript, layout.transcript, layout.viewport.cols);
+  const transcriptLines =
+    state.transcript.length === 0
+      ? renderEmptyTranscript(layout.transcript, layout.viewport.cols, style)
+      : renderTranscript(state.transcript, layout.transcript, layout.viewport.cols);
   const composerLines = renderComposer(state.composer, layout, style);
   const statusLines = renderStatusLine(state.status, layout, style);
 

--- a/src/tui-shell.ts
+++ b/src/tui-shell.ts
@@ -29,7 +29,7 @@ import { MEDIUM_MARK, VERSION, WIDE_WORDMARK } from "./product-banner.js";
 export const COMPOSER_MAX_ROWS = 8;
 export const COMPOSER_MIN_ROWS = 1;
 export const IDENTITY_MAX_ROWS = 7;
-export const STATUS_ROWS = 1;
+export const STATUS_ROWS = 2;
 
 // Minimum terminal dimensions before the full-screen shell is used at all; below
 // these the caller falls back to the plain readline REPL so nothing clips.
@@ -194,7 +194,7 @@ export function computeLayout(viewport: Viewport, opts: { composerRows?: number 
   const cols = Math.max(0, Math.floor(viewport.cols));
   const desiredComposer = clamp(opts.composerRows ?? COMPOSER_MIN_ROWS, COMPOSER_MIN_ROWS, COMPOSER_MAX_ROWS);
 
-  const statusRows = rows >= 1 ? STATUS_ROWS : 0;
+  const statusRows = rows >= 2 ? STATUS_ROWS : rows >= 1 ? 1 : 0;
   let remaining = rows - statusRows;
 
   // Identity scales from a full product wordmark to a compact title. Decoration
@@ -235,7 +235,7 @@ export function computeLayout(viewport: Viewport, opts: { composerRows?: number 
 // Desired total composer band height (state rule + bounded input rows).
 export function composerTotalRows(text: string): number {
   const textLines = text === "" ? 1 : text.split("\n").length;
-  return clamp(textLines + 1, 2, COMPOSER_MAX_ROWS);
+  return clamp(textLines + 2, 3, COMPOSER_MAX_ROWS);
 }
 
 // ---------------------------------------------------------------------------
@@ -274,23 +274,49 @@ export function composerMarker(mode: ComposerMode): ComposerMarker {
 // Region renderers (pure)
 // ---------------------------------------------------------------------------
 
-export function renderIdentity(layout: ShellLayout, style: ShellStyle, version: string): string[] {
+function panelLine(text: string, width: number, style: ShellStyle): string {
+  const inner = Math.max(0, width - 4);
+  const body = clipLine(text, inner);
+  return `${style.accent}│${style.reset} ${body}${" ".repeat(Math.max(0, inner - visibleWidth(body)))} ${style.accent}│${style.reset}`;
+}
+
+export function renderIdentity(
+  layout: ShellLayout,
+  style: ShellStyle,
+  version: string,
+  status: StatusInfo,
+): string[] {
   const height = layout.identity.end - layout.identity.start;
   if (height <= 0) return [];
   const cols = layout.viewport.cols;
-  const metadata = `v${version}  ·  terminal-native coding agent`;
-  if (height >= 7 && cols >= 44) {
+  const logoWidth = Math.max(...WIDE_WORDMARK.map((line) => visibleWidth(line)));
+  const gap = 2;
+  const panelWidth = Math.min(42, cols - logoWidth - gap);
+  if (height >= 7 && panelWidth >= 30) {
+    const panel = [
+      `${style.accent}┌${"─".repeat(panelWidth - 2)}┐${style.reset}`,
+      panelLine(`${style.bold}>_ OH MY CLI${style.reset}  ${style.dim}(v${version})${style.reset}`, panelWidth, style),
+      panelLine("", panelWidth, style),
+      panelLine(`${status.model}  (/model to change)`, panelWidth, style),
+      panelLine(status.workspace, panelWidth, style),
+      `${style.accent}└${"─".repeat(panelWidth - 2)}┘${style.reset}`,
+    ];
     const rows = WIDE_WORDMARK.map((line, index) => {
       const tone = index < 2 ? style.accent : style.accentSoft;
-      return `${tone}${style.bold}${line}${style.reset}`;
+      const logo = `${tone}${style.bold}${line}${style.reset}${" ".repeat(Math.max(0, logoWidth - visibleWidth(line)))}`;
+      return `${logo}${" ".repeat(gap)}${panel[index] ?? ""}`;
     });
-    return [...rows, `${style.dim}${clipLine(metadata, cols)}${style.reset}`, ""];
+    return [
+      ...rows,
+      `${" ".repeat(logoWidth + gap)}${panel[5] ?? ""}`,
+      `${style.dim}Tips: use @path to add files, or Ctrl+K to browse commands.${style.reset}`,
+    ];
   }
   if (height >= 2 && cols >= 20) {
     const mark = MEDIUM_MARK[0] ?? "OMC";
     return [
       `${style.accent}${style.bold}${clipLine(mark, cols)}${style.reset}`,
-      `${style.dim}${clipLine(`OH MY CLI  ${metadata}`, cols)}${style.reset}`,
+      `${style.dim}${clipLine(`v${version}  ·  ${status.model}  ·  ${status.workspace}`, cols)}${style.reset}`,
     ];
   }
   return [`${style.accent}${style.bold}${clipLine(`OH MY CLI  v${version}`, cols)}${style.reset}`];
@@ -302,40 +328,31 @@ export function renderStatusLine(info: StatusInfo, layout: ShellLayout, style: S
   const cols = layout.viewport.cols;
   // Only non-secret operational state: model, redacted workspace, context usage
   // when known, and approval mode. No api key, base URL, or other credential.
-  const parts = [
-    info.model,
-    `approval ${info.approvalMode}`,
-    info.workspace,
-    info.contextUsage ? info.contextUsage : null,
-  ].filter((p): p is string => Boolean(p));
-  const indicator = `${style.success}●${style.reset}`;
-  return [`${indicator} ${style.dim}${clipLine(parts.join("  ·  "), Math.max(0, cols - 2))}${style.reset}`];
+  const primary = [info.workspace, info.model, info.contextUsage].filter((p): p is string => Boolean(p));
+  const first = `${style.success}→${style.reset} ${style.dim}${clipLine(primary.join("  ·  "), Math.max(0, cols - 2))}${style.reset}`;
+  if (height === 1) return [first];
+  const second = `  ${style.dim}${clipLine(`approval ${info.approvalMode}  ·  ? shortcuts  ·  Ctrl+C exit`, Math.max(0, cols - 2))}${style.reset}`;
+  return [first, second];
 }
 
-function renderEmptyTranscript(region: Region, cols: number, style: ShellStyle): string[] {
+function renderEmptyTranscript(region: Region, _cols: number, _style: ShellStyle): string[] {
   const height = Math.max(0, region.end - region.start);
   if (height === 0) return [];
-  const content = [
-    `${style.accent}${style.bold}${clipLine("Ready for your next task", cols)}${style.reset}`,
-    `${style.dim}${clipLine("Ask a question, reference @files, or open commands with Ctrl+K.", cols)}${style.reset}`,
-    "",
-    `${style.dim}${clipLine("/help  explore capabilities    /status  inspect this session", cols)}${style.reset}`,
-  ];
-  const top = Math.max(1, Math.min(3, Math.floor((height - content.length) / 3)));
-  const lines = Array.from({ length: top }, () => "");
-  lines.push(...content.slice(0, Math.max(0, height - top)));
-  while (lines.length < height) lines.push("");
-  return lines.slice(0, height);
+  return Array.from({ length: height }, () => "");
 }
 
 function entryPrefix(kind: TranscriptKind): string {
   switch (kind) {
     case "user":
       return "> ";
+    case "assistant":
+      return "◆ ";
+    case "streaming":
+      return "✦ ";
     case "tool":
-      return "· ";
+      return "● ";
     case "notice":
-      return "# ";
+      return "• ";
     case "error":
       return "! ";
     default:
@@ -373,8 +390,12 @@ export function renderTranscript(entries: TranscriptEntry[], region: Region, col
 function renderRule(label: string, cols: number, style: ShellStyle): string {
   const labelCells = Array.from(label).length;
   if (cols <= labelCells) return clipLine(label, cols);
-  const fill = cols - labelCells - 1;
-  return `${style.accent}${style.bold}${label}${style.reset} ${style.dim}${"─".repeat(fill)}${style.reset}`;
+  const fill = Math.max(0, cols - labelCells - 3);
+  return `${style.accent}${"─".repeat(fill)}${style.reset} ${style.dim}${label}${style.reset} ${style.accent}─${style.reset}`;
+}
+
+function renderBottomRule(cols: number, style: ShellStyle): string {
+  return `${style.accent}${"─".repeat(cols)}${style.reset}`;
 }
 
 // Render the composer band. When there is room (>= 2 rows) the first row is a
@@ -385,26 +406,28 @@ export function renderComposer(state: ComposerState, layout: ShellLayout, style:
   if (height === 0) return [];
   const cols = layout.viewport.cols;
   const marker = composerMarker(state.mode);
-  const label = `${marker.glyph} [${marker.label}]`;
-  const useRule = height >= 2;
-  const textHeight = useRule ? height - 1 : height;
+  const label = `${marker.glyph} ${marker.label}`;
+  const useFrame = height >= 3;
+  const useTopRule = height >= 2;
+  const textHeight = height - (useTopRule ? 1 : 0) - (useFrame ? 1 : 0);
 
   const lines: string[] = [];
-  if (useRule) lines.push(renderRule(label, cols, style));
+  if (useTopRule) lines.push(renderRule(label, cols, style));
 
-  const lead = useRule ? "" : `${marker.glyph} `;
+  const lead = `${marker.glyph} `;
   const bodyWidth = Math.max(1, cols - Array.from(lead).length);
 
   if (state.text === "") {
     const showPlaceholder =
       state.mode === "idle" || state.mode === "focused" || state.mode === "multiline";
     const ph = showPlaceholder ? clipLine(state.placeholder, bodyWidth) : "";
-    lines.push(lead + (ph ? `${style.dim}${ph}${style.reset}` : ""));
+    lines.push(`${style.accent}${lead}${style.reset}${ph ? `${style.dim}${ph}${style.reset}` : ""}`);
   } else {
     const wrapped = wrapText(state.text, bodyWidth);
     const shown = wrapped.slice(Math.max(0, wrapped.length - textHeight));
-    for (const w of shown) lines.push(lead + w);
+    for (const w of shown) lines.push(`${style.accent}${lead}${style.reset}${w}`);
   }
+  if (useFrame) lines.push(renderBottomRule(cols, style));
   return lines.slice(0, height);
 }
 
@@ -417,7 +440,7 @@ export function composeScreen(state: ShellState): ComposedScreen {
   const composerRows = composerTotalRows(state.composer.text);
   const layout = computeLayout(state.viewport, { composerRows });
 
-  const identityLines = renderIdentity(layout, style, state.version);
+  const identityLines = renderIdentity(layout, style, state.version, state.status);
   const transcriptLines =
     state.transcript.length === 0
       ? renderEmptyTranscript(layout.transcript, layout.viewport.cols, style)

--- a/tests/unit/tui-shell.test.ts
+++ b/tests/unit/tui-shell.test.ts
@@ -200,6 +200,22 @@ describe("tui-shell: transcript anchors newest content at the bottom", () => {
 });
 
 describe("tui-shell: whole-screen composition", () => {
+  it("uses the responsive product wordmark and a useful first-run empty state", () => {
+    const text = renderShell(baseState()).join("\n");
+    expect(text).toContain("████ █  █");
+    expect(text).toContain("terminal-native coding agent");
+    expect(text).toContain("Ready for your next task");
+    expect(text).toContain("reference @files");
+    expect(text).toContain("Ctrl+K");
+  });
+
+  it("reduces the identity before sacrificing the composer on short terminals", () => {
+    const text = renderShell(baseState({ viewport: { rows: 12, cols: 40 } })).join("\n");
+    expect(text).toContain("OH MY CLI");
+    expect(text).toContain("[edit]");
+    expect(text).not.toContain("████ █  █");
+  });
+
   it("renders exactly viewport.rows rows with the composer above the status footer", () => {
     const state = baseState({
       transcript: [{ kind: "assistant", text: "answer" }],

--- a/tests/unit/tui-shell.test.ts
+++ b/tests/unit/tui-shell.test.ts
@@ -43,10 +43,10 @@ describe("tui-shell: computeLayout viewport allocation", () => {
     expect(layout.status.end).toBe(24);
   });
 
-  it("always keeps a status footer row when any space exists", () => {
+  it("uses a two-row status footer when space allows", () => {
     for (const rows of [1, 2, 4, 8, 24, 50]) {
       const layout = computeLayout({ rows, cols: 80 }, { composerRows: 2 });
-      expect(layout.statusRows).toBe(1);
+      expect(layout.statusRows).toBe(rows === 1 ? 1 : 2);
       expect(layout.status.end).toBe(rows);
     }
   });
@@ -72,8 +72,8 @@ describe("tui-shell: computeLayout viewport allocation", () => {
 
 describe("tui-shell: bounded multiline growth", () => {
   it("caps the composer band height regardless of input line count", () => {
-    expect(composerTotalRows("")).toBe(2); // rule + 1
-    expect(composerTotalRows("a\nb\nc")).toBe(4);
+    expect(composerTotalRows("")).toBe(3); // top rule + input + bottom rule
+    expect(composerTotalRows("a\nb\nc")).toBe(5);
     const many = Array.from({ length: 30 }, (_, i) => `line${i}`).join("\n");
     expect(composerTotalRows(many)).toBe(COMPOSER_MAX_ROWS);
   });
@@ -119,7 +119,7 @@ describe("tui-shell: composer states are color-independent", () => {
         layout,
         shellStyle(false),
       );
-      expect(lines.join("\n")).toContain(`[${composerMarker(mode).label}]`);
+      expect(lines.join("\n")).toContain(`${composerMarker(mode).glyph} ${composerMarker(mode).label}`);
       expect(lines.join("\n")).not.toMatch(ANSI);
     }
   });
@@ -164,8 +164,8 @@ describe("tui-shell: status line is readable and credential-free", () => {
       approvalMode: "default",
     };
     const layout = computeLayout({ rows: 24, cols: 40 });
-    const line = renderStatusLine(info, layout, shellStyle(false)).join("");
-    expect(visibleWidth(line)).toBeLessThanOrEqual(40);
+    const lines = renderStatusLine(info, layout, shellStyle(false));
+    for (const line of lines) expect(visibleWidth(line)).toBeLessThanOrEqual(40);
   });
 });
 
@@ -200,19 +200,19 @@ describe("tui-shell: transcript anchors newest content at the bottom", () => {
 });
 
 describe("tui-shell: whole-screen composition", () => {
-  it("uses the responsive product wordmark and a useful first-run empty state", () => {
+  it("uses a Qwen-style product header and quiet first-run canvas", () => {
     const text = renderShell(baseState()).join("\n");
     expect(text).toContain("████ █  █");
-    expect(text).toContain("terminal-native coding agent");
-    expect(text).toContain("Ready for your next task");
-    expect(text).toContain("reference @files");
+    expect(text).toContain(">_ OH MY CLI");
+    expect(text).toContain("(/model to change)");
+    expect(text).toContain("Tips: use @path");
     expect(text).toContain("Ctrl+K");
   });
 
   it("reduces the identity before sacrificing the composer on short terminals", () => {
     const text = renderShell(baseState({ viewport: { rows: 12, cols: 40 } })).join("\n");
-    expect(text).toContain("OH MY CLI");
-    expect(text).toContain("[edit]");
+    expect(text).toContain("███ █   █ ███");
+    expect(text).toContain("❯ edit");
     expect(text).not.toContain("████ █  █");
   });
 
@@ -260,7 +260,7 @@ describe("tui-shell: whole-screen composition", () => {
     expect(text).not.toMatch(ANSI);
     expect(text).toContain("plain answer");
     expect(text).toContain("typed");
-    expect(text).toContain("[edit]");
+    expect(text).toContain("❯ edit");
   });
 });
 


### PR DESCRIPTION
## Motivation

The full-screen first-run experience rendered only a compact title above an otherwise empty viewport, even though the product already shipped a responsive wordmark. This made the interactive shell look unfinished and left users without orientation or a clear next action.

## Changes

- Use the existing responsive product wordmark inside the full-screen shell, with compact fallbacks for constrained terminals.
- Keep the conversation canvas visually quiet and move orientation into one compact tip row above it.
- Frame the composer with accent rules and place repository, model, context, approval, and shortcuts in a quiet two-row footer.
- Keep the transcript, composer, and footer responsive without changing non-interactive output.

## Verification

- `npm run typecheck` — PASS
- `npx vitest run tests/unit/tui-shell.test.ts` — PASS (30 tests)
- `tests/integration/tui-shell.test.ts` within the integration run — PASS (4 tests)
- `npm run build` — PASS
- Local tmux at 120x36 — PASS: Qwen-style wordmark + session panel, quiet conversation canvas, framed composer, and two-row footer
- Existing repository baseline on macOS: the full suite still has unrelated `/var` versus `/private/var` realpath failures in workspace tool tests; no affected module is changed here.

## Exact-head tmux evidence

- Commit: `689a86b369ebc086327f7eff8709f1988dd4a907`
- [PASS report](https://raw.githubusercontent.com/qwen-code-dev-bot/oh-my-cli/e2e-evidence/e2e/689a86b369ebc086327f7eff8709f1988dd4a907/report.md)
- [Terminal screenshot](https://raw.githubusercontent.com/qwen-code-dev-bot/oh-my-cli/e2e-evidence/e2e/689a86b369ebc086327f7eff8709f1988dd4a907/terminal.png)
- [Readable transcript](https://raw.githubusercontent.com/qwen-code-dev-bot/oh-my-cli/e2e-evidence/e2e/689a86b369ebc086327f7eff8709f1988dd4a907/transcript.txt)
- [ANSI capture](https://raw.githubusercontent.com/qwen-code-dev-bot/oh-my-cli/e2e-evidence/e2e/689a86b369ebc086327f7eff8709f1988dd4a907/terminal.ansi)
- [Timeline](https://raw.githubusercontent.com/qwen-code-dev-bot/oh-my-cli/e2e-evidence/e2e/689a86b369ebc086327f7eff8709f1988dd4a907/timeline.json)

## Safety and scope

- No provider, settings, command execution, or non-interactive output behavior changes.
- No credentials or absolute user paths are added to source or test fixtures.
- Only the TUI renderer and its focused tests are changed.
