### PR TITLE
chore(governance): increase idle community discovery cadence

### DIFF
--- a/.autonomy/community.yml
+++ b/.autonomy/community.yml
@@ -1,6 +1,6 @@
 schema: autonomy.openai/v1
-cadenceHours: 24
-maximumLatenessHours: 6
+cadenceHours: 2
+maximumLatenessHours: 1
 registeredSourcesOnly: true
 allowedSourceTypes:
   - official-repository

--- a/.autonomy/prompts/coordinator.md
+++ b/.autonomy/prompts/coordinator.md
@@ -60,18 +60,26 @@ After reconciliation, choose exactly one action in this order:
 5. triage and promote pending user Issues;
 6. run due post-merge targeted dogfood;
 7. run due daily global dogfood;
-8. run the due daily community scan;
-9. acquire the next trusted executable Issue using `issue-policy.yml`; or
-10. enter `idle` after a minimal inbox and recovery check.
+8. decompose the next dependency-ready roadmap parent;
+9. acquire the next trusted executable Issue using `issue-policy.yml`;
+10. run the due community scan; or
+11. enter `idle` after a minimal inbox and recovery check.
 
 Only that action owns product mutation during the tick. Never work on multiple
 Issues or product branches concurrently. A severe security Issue may pause
 ordinary work, but it does not create a second active product mutation.
 
-Community scanning and global dogfood are due every 24 hours. If either is more
-than six hours late while a normal Issue spans ticks, run the overdue
-non-mutating phase at the next commit boundary without releasing the Issue
-lease. Resume development on the following tick.
+Community scanning is due every 2 hours and may be at most one hour late.
+Select it only when there is no active lease; no resumable pull request, CI, or
+post-merge work; no pending user promotion or external intake; no normalized
+Issue awaiting activation; no agent-ready Issue; and no roadmap parent awaiting
+decomposition. Keep a blocked due scan pending until the next truly idle
+coordinator tick.
+
+Global dogfood is due every 24 hours. If it is more than six hours late while a
+normal Issue spans ticks, run the overdue non-mutating phase at the next commit
+boundary without releasing the Issue lease. Resume development on the following
+tick.
 
 ## States
 

--- a/tests/unit/autonomy-community-policy.test.ts
+++ b/tests/unit/autonomy-community-policy.test.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const communityPolicy = fs.readFileSync(
+  path.join(root, ".autonomy/community.yml"),
+  "utf8",
+);
+const coordinatorContract = fs.readFileSync(
+  path.join(root, ".autonomy/prompts/coordinator.md"),
+  "utf8",
+);
+const normalizedCoordinatorContract = coordinatorContract.replace(/\s+/g, " ");
+
+describe("community discovery governance", () => {
+  it("runs every two hours with at most one hour of lateness", () => {
+    expect(communityPolicy).toMatch(/^cadenceHours: 2$/m);
+    expect(communityPolicy).toMatch(/^maximumLatenessHours: 1$/m);
+    expect(coordinatorContract).toContain(
+      "Community scanning is due every 2 hours and may be at most one hour late.",
+    );
+  });
+
+  it("selects community discovery only after executable work and decomposition", () => {
+    const roadmap = coordinatorContract.indexOf(
+      "decompose the next dependency-ready roadmap parent",
+    );
+    const executable = coordinatorContract.indexOf(
+      "acquire the next trusted executable Issue",
+    );
+    const community = coordinatorContract.indexOf("run the due community scan");
+
+    expect(roadmap).toBeGreaterThan(-1);
+    expect(executable).toBeGreaterThan(roadmap);
+    expect(community).toBeGreaterThan(executable);
+  });
+
+  it("preserves a due scan until every true-idle blocker is absent", () => {
+    for (const blocker of [
+      "active lease",
+      "resumable pull request, CI, or post-merge work",
+      "pending user promotion or external intake",
+      "normalized Issue awaiting activation",
+      "agent-ready Issue",
+      "roadmap parent awaiting decomposition",
+    ]) {
+      expect(normalizedCoordinatorContract).toContain(blocker);
+    }
+    expect(normalizedCoordinatorContract).toContain(
+      "Keep a blocked due scan pending until the next truly idle coordinator tick.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Increase registered-source community discovery from once every 24 hours to once every 2 hours, with at most 1 hour of lateness, while preserving normal development as the higher-priority path.

The coordinator contract now selects community discovery only after recovery, intake, resumable PR/CI/post-merge work, roadmap decomposition, and executable issues are exhausted. A due scan that is blocked remains pending until the next truly idle tick. Daily global dogfood keeps its existing 24-hour cadence and 6-hour lateness behavior.

## Reviewer Test Plan

- Confirm a due community scan is selected only when no lease, resumable delivery work, intake or promotion, normalized ready work, agent-ready issue, or roadmap decomposition remains.
- Confirm a blocked due scan stays pending and runs on the next truly idle coordinator tick.
- Confirm registered sources remain the only permitted discovery inputs.
- After merge and runtime reconciliation, confirm `qrun validate-contract` and `qrun verify` pass and that the durable scheduler records the next due time without rewriting the ledger.

## Validation

- Focused community governance test: 3 passed
- Typecheck: passed
- Build: passed
- Full unit suite: 83 files, 1677 tests passed
- Diff/format checks: passed

<details><summary>中文说明</summary>

将仅限注册来源的社区发现频率从每 24 小时提高到每 2 小时，最大延迟 1 小时；只有在 lease、PR/CI/post-merge、用户 intake/promotion、待激活工作、agent-ready Issue 和 roadmap 拆解均为空时才允许执行。被正常开发阻塞的到期扫描会保持 pending，等下一个真正空闲 tick 再运行。

</details>

Fixes #219