### PR TITLE
feat(tui): render Workflow execution console

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,14 @@ import {
   resolvePreToolUseHooks,
   type PreToolUseHook,
 } from "./hook-contract.js";
-import { runWorkflow, formatWorkflowStepLine } from "./workflow-runner.js";
+import {
+  runWorkflow,
+  formatWorkflowStart,
+  formatWorkflowStepStart,
+  formatWorkflowStepLine,
+  formatWorkflowOutcome,
+  workflowConsoleStyle,
+} from "./workflow-runner.js";
 import {
   collectProfileList,
   formatProfileList,
@@ -1864,19 +1871,42 @@ program
           process.exit(2);
         }
         let report;
+        const workflowFormat = {
+          style: workflowConsoleStyle(
+            detectColorDepth({
+              noColor: opts.color === false,
+              env: process.env,
+              isTTY: process.stdout.isTTY,
+            }),
+          ),
+          width: process.stdout.columns ?? 80,
+        };
         try {
           report = await runWorkflow({
             name,
             settingsPath: resolveSettingsPath(opts.settings),
             workspace: opts.workspace,
             env: process.env,
+            onWorkflowStart:
+              format === "text"
+                ? (start) => {
+                    process.stdout.write(formatWorkflowStart(start, workflowFormat) + "\n");
+                  }
+                : undefined,
+            onStepStart:
+              format === "text"
+                ? (step, stepsTotal) => {
+                    process.stdout.write(
+                      formatWorkflowStepStart(step, stepsTotal, workflowFormat) + "\n",
+                    );
+                  }
+                : undefined,
             onStepEnd:
               format === "text"
                 ? (step, stepsTotal) => {
-                    process.stdout.write(formatWorkflowStepLine(step, stepsTotal) + "\n");
-                    if (!step.ok && step.reason) {
-                      process.stdout.write(`    reason: ${step.reason}\n`);
-                    }
+                    process.stdout.write(
+                      formatWorkflowStepLine(step, stepsTotal, workflowFormat) + "\n",
+                    );
                   }
                 : undefined,
           });
@@ -1888,15 +1918,7 @@ program
         if (format === "json") {
           process.stdout.write(JSON.stringify(report) + "\n");
         } else {
-          if (report.stepsRun < report.stepsTotal) {
-            process.stdout.write(
-              `  Steps ${report.stepsRun + 1}-${report.stepsTotal}: skipped (halted)\n`,
-            );
-          }
-          process.stdout.write(
-            `Workflow "${report.workflow}": ${report.result} ` +
-              `(${report.stepsRun}/${report.stepsTotal} steps, ${report.elapsedMs}ms)\n`,
-          );
+          process.stdout.write(formatWorkflowOutcome(report, workflowFormat) + "\n");
         }
         process.exit(report.result === "completed" ? 0 : 1);
       }

--- a/src/workflow-runner.ts
+++ b/src/workflow-runner.ts
@@ -13,6 +13,7 @@
 import { spawn } from "node:child_process";
 import { redactSecrets, redactHomePath } from "./permission-impact.js";
 import { parseHeadlessStream, terminalRecord } from "./headless-protocol.js";
+import type { ColorDepth } from "./product-banner.js";
 import {
   resolveWorkflow,
   WORKFLOW_CONTRACT_SCHEMA,
@@ -49,6 +50,11 @@ export interface WorkflowRunReport {
   elapsedMs: number;
   settings: string;
   workspace: string;
+}
+
+export interface WorkflowRunStart {
+  workflow: string;
+  stepsTotal: number;
 }
 
 export interface StepExecutionContext {
@@ -163,6 +169,8 @@ export interface RunWorkflowOptions {
   env?: Record<string, string | undefined>;
   /** Override the step executor (tests). Defaults to spawning the CLI -p path. */
   executor?: StepExecutor;
+  /** Invoked with the redacted plan before the first executor call. */
+  onWorkflowStart?: (start: WorkflowRunStart) => void;
   /** Invoked with the redacted step view before a step runs (streaming). */
   onStepStart?: (step: WorkflowStepResult, stepsTotal: number) => void;
   /** Invoked with the redacted step result after a step completes (streaming). */
@@ -178,16 +186,22 @@ export async function runWorkflow(opts: RunWorkflowOptions): Promise<WorkflowRun
   const resolved = resolveWorkflow(opts.name, { settingsPath: opts.settingsPath });
   const definition = resolved.definition;
   const total = definition.steps.length;
+  const displayPrompts = definition.steps.map((step) =>
+    redactPromptForDisplay(step.prompt, opts.workspace),
+  );
+  opts.onWorkflowStart?.({
+    workflow: definition.name,
+    stepsTotal: total,
+  });
 
   const startedAt = Date.now();
   const steps: WorkflowStepResult[] = [];
   let result: "completed" | "failed" = "completed";
 
   for (let i = 0; i < total; i++) {
-    const displayPrompt = redactPromptForDisplay(definition.steps[i].prompt, opts.workspace);
     const pending: WorkflowStepResult = {
       index: i,
-      prompt: displayPrompt,
+      prompt: displayPrompts[i],
       ok: false,
       exitCode: null,
       elapsedMs: 0,
@@ -202,7 +216,7 @@ export async function runWorkflow(opts: RunWorkflowOptions): Promise<WorkflowRun
     });
     const stepResult: WorkflowStepResult = {
       index: i,
-      prompt: displayPrompt,
+      prompt: displayPrompts[i],
       ok: exec.ok,
       exitCode: exec.exitCode,
       elapsedMs: Date.now() - stepStart,
@@ -234,15 +248,204 @@ export async function runWorkflow(opts: RunWorkflowOptions): Promise<WorkflowRun
   };
 }
 
-// A single redacted line for one step, shared by the streaming and full-report
-// paths so the human rendering never diverges.
-export function formatWorkflowStepLine(step: WorkflowStepResult, stepsTotal: number): string {
-  const status = step.ok ? "ok" : "FAILED";
-  return `  Step ${step.index + 1}/${stepsTotal}: ${step.prompt} — ${status} (${step.elapsedMs}ms)`;
+export interface WorkflowConsoleStyle {
+  bold: string;
+  dim: string;
+  accent: string;
+  accentWarm: string;
+  success: string;
+  error: string;
+  reset: string;
+}
+
+export interface WorkflowFormatOptions {
+  style?: WorkflowConsoleStyle;
+  width?: number;
+}
+
+const PLAIN_WORKFLOW_STYLE: WorkflowConsoleStyle = {
+  bold: "",
+  dim: "",
+  accent: "",
+  accentWarm: "",
+  success: "",
+  error: "",
+  reset: "",
+};
+
+export function workflowConsoleStyle(depth: ColorDepth): WorkflowConsoleStyle {
+  if (depth === "none") return { ...PLAIN_WORKFLOW_STYLE };
+  if (depth === "basic") {
+    return {
+      bold: "\x1b[1m",
+      dim: "\x1b[2m",
+      accent: "\x1b[34m",
+      accentWarm: "\x1b[35m",
+      success: "\x1b[32m",
+      error: "\x1b[31m",
+      reset: "\x1b[0m",
+    };
+  }
+  return {
+    bold: "\x1b[1m",
+    dim: "\x1b[2m",
+    accent: "\x1b[38;5;27m",
+    accentWarm: "\x1b[38;5;176m",
+    success: "\x1b[38;5;114m",
+    error: "\x1b[38;5;203m",
+    reset: "\x1b[0m",
+  };
+}
+
+function workflowFormatOptions(opts: WorkflowFormatOptions): {
+  style: WorkflowConsoleStyle;
+  width: number;
+} {
+  return {
+    style: opts.style ?? PLAIN_WORKFLOW_STYLE,
+    width: Math.max(1, Math.floor(opts.width ?? 80)),
+  };
+}
+
+function clipWorkflowText(text: string, width: number): string {
+  const cells = Array.from(text);
+  if (cells.length <= width) return text;
+  if (width <= 1) return "…".slice(0, width);
+  return cells.slice(0, width - 1).join("") + "…";
+}
+
+function workflowStateLine(input: {
+  glyph: string;
+  label: string;
+  position?: string;
+  detail: string;
+  tone: string;
+  style: WorkflowConsoleStyle;
+  width: number;
+}): string {
+  const position = input.position ? `${input.position}  ` : "";
+  const prefix = `${input.glyph} ${input.label.padEnd(8)} ${position}`;
+  const plain = clipWorkflowText(prefix + input.detail, input.width);
+  const detailStart = Math.min(prefix.length, Array.from(plain).length);
+  const visiblePrefix = Array.from(plain).slice(0, detailStart).join("");
+  const visibleDetail = Array.from(plain).slice(detailStart).join("");
+  return `${input.tone}${visiblePrefix}${input.style.reset}${visibleDetail}`;
+}
+
+export function formatWorkflowStart(
+  start: WorkflowRunStart,
+  opts: WorkflowFormatOptions = {},
+): string {
+  const { style, width } = workflowFormatOptions(opts);
+  const lines = [
+    clipWorkflowText("╭─ DYNAMIC WORKFLOW", width),
+    clipWorkflowText(
+      `│  ${start.workflow}  ·  ${start.stepsTotal} step${start.stepsTotal === 1 ? "" : "s"}  ·  SEQUENTIAL`,
+      width,
+    ),
+    clipWorkflowText("╰─ execution started", width),
+  ];
+  return [
+    `${style.accentWarm}${lines[0]}${style.reset}`,
+    `${style.bold}${lines[1]}${style.reset}`,
+    `${style.dim}${lines[2]}${style.reset}`,
+  ].join("\n");
+}
+
+export function formatWorkflowStepStart(
+  step: WorkflowStepResult,
+  stepsTotal: number,
+  opts: WorkflowFormatOptions = {},
+): string {
+  const { style, width } = workflowFormatOptions(opts);
+  const position = `${step.index + 1}/${stepsTotal}`;
+  const lines = [
+    workflowStateLine({
+      glyph: "◆",
+      label: "RUNNING",
+      position,
+      detail: step.prompt,
+      tone: style.accentWarm,
+      style,
+      width,
+    }),
+  ];
+  const remaining = Math.max(0, stepsTotal - step.index - 1);
+  if (remaining > 0) {
+    lines.push(
+      workflowStateLine({
+        glyph: "○",
+        label: "QUEUED",
+        detail: `${remaining} step${remaining === 1 ? "" : "s"} remaining`,
+        tone: style.dim,
+        style,
+        width,
+      }),
+    );
+  }
+  return lines.join("\n");
+}
+
+// A redacted completion line for one step. The same formatter is used by the
+// streaming and full-report paths so terminal state never diverges.
+export function formatWorkflowStepLine(
+  step: WorkflowStepResult,
+  stepsTotal: number,
+  opts: WorkflowFormatOptions = {},
+): string {
+  const { style, width } = workflowFormatOptions(opts);
+  const line = workflowStateLine({
+    glyph: step.ok ? "●" : "✕",
+    label: step.ok ? "DONE" : "FAILED",
+    position: `${step.index + 1}/${stepsTotal}`,
+    detail: `${step.prompt}  ·  ${step.elapsedMs}ms`,
+    tone: step.ok ? style.success : style.error,
+    style,
+    width,
+  });
+  if (step.ok || !step.reason) return line;
+  const reason = clipWorkflowText(`│   reason  ${step.reason}`, width);
+  return `${line}\n${style.error}${reason}${style.reset}`;
+}
+
+export function formatWorkflowOutcome(
+  report: WorkflowRunReport,
+  opts: WorkflowFormatOptions = {},
+): string {
+  const { style, width } = workflowFormatOptions(opts);
+  const lines: string[] = [];
+  const skipped = report.stepsTotal - report.stepsRun;
+  if (skipped > 0) {
+    lines.push(
+      workflowStateLine({
+        glyph: "○",
+        label: "SKIPPED",
+        detail: `${skipped} step${skipped === 1 ? "" : "s"}  ·  halted after ${report.stepsRun}/${report.stepsTotal}`,
+        tone: style.dim,
+        style,
+        width,
+      }),
+    );
+  }
+  lines.push(`${style.accent}${clipWorkflowText("╭─ OUTCOME", width)}${style.reset}`);
+  const completed = report.result === "completed";
+  const outcome = completed
+    ? `│  ✓ COMPLETED  ${report.stepsRun}/${report.stepsTotal} steps  ·  ${report.elapsedMs}ms`
+    : `│  ✕ FAILED     ${report.stepsRun}/${report.stepsTotal} steps  ·  ${report.elapsedMs}ms`;
+  lines.push(
+    `${completed ? style.success : style.error}${clipWorkflowText(outcome, width)}${style.reset}`,
+  );
+  lines.push(
+    `${style.dim}${clipWorkflowText(`╰─ ${report.workflow}`, width)}${style.reset}`,
+  );
+  return lines.join("\n");
 }
 
 // A redacted, human-readable summary of a workflow run.
-export function formatWorkflowRun(report: WorkflowRunReport): string {
+export function formatWorkflowRun(
+  report: WorkflowRunReport,
+  opts: WorkflowFormatOptions = {},
+): string {
   const lines: string[] = [];
   lines.push(`Workflow:  ${report.workflow}`);
   lines.push(
@@ -251,10 +454,7 @@ export function formatWorkflowRun(report: WorkflowRunReport): string {
   lines.push(`Settings:  ${report.settings}`);
   lines.push(`Workspace: ${report.workspace}`);
   for (const step of report.steps) {
-    lines.push(formatWorkflowStepLine(step, report.stepsTotal));
-    if (!step.ok && step.reason) {
-      lines.push(`    reason: ${step.reason}`);
-    }
+    lines.push(formatWorkflowStepLine(step, report.stepsTotal, opts));
   }
   if (report.stepsRun < report.stepsTotal) {
     lines.push(`  Steps ${report.stepsRun + 1}-${report.stepsTotal}: skipped (halted)`);

--- a/tests/integration/workflow-contract.test.ts
+++ b/tests/integration/workflow-contract.test.ts
@@ -189,9 +189,37 @@ describe("Integration: workflow contract", () => {
       runEnv(home),
     );
     expect(r.code).toBe(0);
-    expect(r.stdout).toContain("Step 1/2");
-    expect(r.stdout).toContain("Step 2/2");
-    expect(r.stdout).toContain('Workflow "ci-readonly": completed (2/2 steps');
+    expect(r.stdout).toContain("DYNAMIC WORKFLOW");
+    expect(r.stdout).toContain("ci-readonly");
+    expect(r.stdout).toContain("◆ RUNNING  1/2");
+    expect(r.stdout).toContain("● DONE     1/2");
+    expect(r.stdout).toContain("◆ RUNNING  2/2");
+    expect(r.stdout).toContain("● DONE     2/2");
+    expect(r.stdout).toContain("✓ COMPLETED  2/2 steps");
+  });
+
+  it("makes a halted human-readable run explicit without running queued work", async () => {
+    server.setResponses([
+      { type: "text", failWith: { status: 500 } },
+      { type: "text", failWith: { status: 500 } },
+      { type: "text", failWith: { status: 500 } },
+      { type: "text", failWith: { status: 500 } },
+      { type: "text", failWith: { status: 500 } },
+    ]);
+    const home = homeWith({
+      workflows: {
+        contractVersion: 1,
+        definitions: { wf: { steps: [{ prompt: "one" }, { prompt: "two" }] } },
+      },
+    });
+    const r = await runCli(["--run-workflow", "wf", "--workspace", tmpRoot], runEnv(home), 40_000);
+    expect(r.code).toBe(1);
+    expect(r.stdout).toContain("◆ RUNNING  1/2");
+    expect(r.stdout).toContain("✕ FAILED   1/2");
+    expect(r.stdout).toContain("│   reason");
+    expect(r.stdout).toContain("○ SKIPPED  1 step");
+    expect(r.stdout).toContain("│  ✕ FAILED     1/2 steps");
+    expect(server.requests.length).toBeGreaterThan(0);
   });
 
   it("exits 2 on an unknown workflow name", async () => {

--- a/tests/unit/workflow-runner.test.ts
+++ b/tests/unit/workflow-runner.test.ts
@@ -5,8 +5,12 @@ import path from "node:path";
 import {
   runWorkflow,
   redactPromptForDisplay,
+  formatWorkflowStart,
+  formatWorkflowStepStart,
   formatWorkflowStepLine,
+  formatWorkflowOutcome,
   formatWorkflowRun,
+  workflowConsoleStyle,
 } from "../../src/workflow-runner.js";
 import type {
   StepExecutor,
@@ -155,6 +159,30 @@ describe("runWorkflow: sequential execution and safe failure defaults", () => {
     expect(starts).toEqual([0, 1]);
     expect(ends).toEqual([0, 1]);
   });
+
+  it("announces the redacted workflow plan before the first executor call", async () => {
+    const settings = writeSettings({
+      workflows: {
+        contractVersion: 1,
+        definitions: { wf: { steps: [{ prompt: "inspect one" }, { prompt: "verify two" }] } },
+      },
+    });
+    const events: string[] = [];
+    await runWorkflow({
+      name: "wf",
+      settingsPath: settings,
+      workspace: tmpDir(),
+      env: {},
+      executor: async () => {
+        events.push("execute");
+        return { ok: true, exitCode: 0 };
+      },
+      onWorkflowStart: (start) => {
+        events.push(`start:${start.workflow}:${start.stepsTotal}`);
+      },
+    });
+    expect(events).toEqual(["start:wf:2", "execute", "execute"]);
+  });
 });
 
 describe("redactPromptForDisplay", () => {
@@ -193,8 +221,8 @@ describe("formatWorkflowStepLine and formatWorkflowRun", () => {
   };
 
   it("renders an ok step and a failed step with reason", () => {
-    expect(formatWorkflowStepLine(step, 2)).toContain("Step 1/2");
-    expect(formatWorkflowStepLine(step, 2)).toContain("ok");
+    expect(formatWorkflowStepLine(step, 2)).toContain("● DONE");
+    expect(formatWorkflowStepLine(step, 2)).toContain("1/2");
     const failed: WorkflowStepResult = { ...step, ok: false, reason: "provider_error" };
     expect(formatWorkflowStepLine(failed, 2)).toContain("FAILED");
   });
@@ -214,8 +242,81 @@ describe("formatWorkflowStepLine and formatWorkflowRun", () => {
       workspace: "~/ws",
     });
     expect(out).toContain("Workflow:  wf");
-    expect(out).toContain("reason: boom");
+    expect(out).toContain("reason  boom");
     expect(out).toContain("Steps 2-3: skipped (halted)");
     expect(out).toContain("Result:    failed (1/3 steps");
+  });
+
+  it("renders an append-only execution console with truthful state labels", () => {
+    const style = workflowConsoleStyle("none");
+    expect(
+      formatWorkflowStart(
+        { workflow: "release-readiness", stepsTotal: 3 },
+        { style, width: 72 },
+      ),
+    ).toContain("DYNAMIC WORKFLOW");
+    expect(
+      formatWorkflowStepStart(
+        { index: 0, prompt: "scope", ok: false, exitCode: null, elapsedMs: 0 },
+        3,
+        { style, width: 72 },
+      ),
+    ).toContain("◆ RUNNING");
+    expect(
+      formatWorkflowStepStart(
+        { index: 0, prompt: "scope", ok: false, exitCode: null, elapsedMs: 0 },
+        3,
+        { style, width: 72 },
+      ),
+    ).toContain("○ QUEUED");
+    expect(formatWorkflowStepLine(step, 2, { style, width: 72 })).toContain("● DONE");
+    const failed: WorkflowStepResult = { ...step, ok: false, reason: "provider_error" };
+    const failure = formatWorkflowStepLine(failed, 2, { style, width: 72 });
+    expect(failure).toContain("✕ FAILED");
+    expect(failure).toContain("reason  provider_error");
+    expect(
+      formatWorkflowOutcome(
+        {
+          schema: "oh-my-cli.workflow-contract",
+          version: 1,
+          contractVersion: 1,
+          workflow: "wf",
+          result: "failed",
+          stepsTotal: 3,
+          stepsRun: 1,
+          steps: [failed],
+          elapsedMs: 42,
+          settings: "~/.oh-my-cli/settings.json",
+          workspace: "~/ws",
+        },
+        { style, width: 72 },
+      ),
+    ).toContain("○ SKIPPED  2 steps");
+  });
+
+  it("keeps narrow and no-color output bounded and free of ANSI", () => {
+    const style = workflowConsoleStyle("none");
+    const out = formatWorkflowStepStart(
+      {
+        index: 0,
+        prompt: "inspect a very long repository boundary before changing anything",
+        ok: false,
+        exitCode: null,
+        elapsedMs: 0,
+      },
+      4,
+      { style, width: 34 },
+    );
+    expect(out).not.toContain("\x1b[");
+    expect(out.split("\n").every((line) => Array.from(line).length <= 34)).toBe(true);
+    expect(out).toContain("…");
+    expect(
+      formatWorkflowStart(
+        { workflow: "wf", stepsTotal: 1 },
+        { style, width: 8 },
+      )
+        .split("\n")
+        .every((line) => Array.from(line).length <= 8),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## What changed

The human-readable `--run-workflow` path now presents sequential runs as an append-only execution console. It prints a compact Workflow header before the first executor call, distinguishes running, queued, completed, failed, and skipped states with both glyphs and ASCII labels, and closes with an exact terminal outcome.

The console uses the product's existing blue, violet, rose, green, and error terminal language when color is available. `--no-color`, redirected output, and reduced-color terminals retain the same hierarchy without relying on color. Long details are clipped to the actual terminal width after existing secret, home-path, and workspace-path redaction.

The JSON path remains a single document with its existing schema and fields. Workflow execution order, settings authority, failure exit codes, and safe halt behavior are unchanged.

## Why

The previous text output emitted only similarly weighted completion lines. Users saw no Workflow frame before the first step completed and had to scan prose to distinguish a failed step from work that never ran. The new hierarchy makes the existing runtime truth visible without adding cursor animation or inventing progress percentages.

Public Workflow product references informed the plan/progress/intervention hierarchy only; no source code, assets, or branding were copied:

- https://x.com/claudeai/status/2010805682434666759
- https://x.com/claudeai/status/2010805687975379045

## Before

```text
Step 1/3: Lock the release scope — ok (191ms)
Step 2/3: Verify the material claims — ok (192ms)
Step 3/3: Produce the release decision — ok (188ms)
Workflow "release-readiness": completed (3/3 steps, 571ms)
```

## After

```text
╭─ DYNAMIC WORKFLOW
│  release-readiness  ·  3 steps  ·  SEQUENTIAL
╰─ execution started
◆ RUNNING  1/3  Lock the release scope
○ QUEUED   2 steps remaining
● DONE     1/3  Lock the release scope  ·  191ms
◆ RUNNING  2/3  Verify the material claims
○ QUEUED   1 step remaining
● DONE     2/3  Verify the material claims  ·  192ms
◆ RUNNING  3/3  Produce the release decision
● DONE     3/3  Produce the release decision  ·  188ms
╭─ OUTCOME
│  ✓ COMPLETED  3/3 steps  ·  571ms
╰─ release-readiness
```

## Verification

- `npm run typecheck`
- `npm run build`
- `npm test` — 91 files, 1768 tests passed
- `npx vitest run tests/integration/workflow-contract.test.ts` — 13 tests passed
- Real 100×34 tmux success and halted-run captures against head `7423c84a65b11c70a8bf194f1d1e8b0c662fecd9`

## Scope boundary

This PR does not implement or unblock the durable `/workflows` browser, persistence, parallel agents, or control actions tracked by #81. It changes no protected governance path.

Closes #257
Related to #76
