### PR TITLE
feat(tui): render the activity stream as progressive-disclosure cards

### DIFF
--- a/src/activity-render.ts
+++ b/src/activity-render.ts
@@ -1,0 +1,131 @@
+// Activity rendering: render the #306 presented activity event stream as
+// progressive-disclosure cards for the mission-control TUI view (Issue #307, the
+// TUI activity-rendering child of #291). Each card shows a status glyph, the
+// event kind, its summary, elapsed time, and a liveness marker; expanding a card
+// reveals its bounded detail. The rendering is a pure function of the presented
+// events plus a small view state (which cards are expanded, follow-mode, and an
+// unread count), so the same events and view state always render the same view,
+// and expanding/collapsing never loses the underlying events.
+//
+// This module returns plain text lines (no ANSI); the TUI panel in tui-shell.ts
+// applies color/style around them, exactly as the mission lifecycle (#314) and
+// background-task panels style their bodies. Keeping rendering pure and
+// style-free makes it unit-testable against fixture event streams and reusable by
+// the Desktop canvas (#318). Reduced-color/no-color degrades to the glyphs and
+// plain text without losing information.
+//
+// Trust boundary: the rendering reads only already-presented events (sanitized by
+// the #306 mapper); it executes nothing and adds no untrusted content.
+
+import type { PresentedEvent, EventStatus } from "./event-presentation.js";
+
+// A stable glyph per activity status, so a card communicates status at a glance
+// without relying on color alone.
+const STATUS_GLYPHS: Record<EventStatus, string> = {
+  pending: "○",
+  active: "◆",
+  completed: "✓",
+  failed: "✕",
+  waiting: "◇",
+  cancelled: "⊘",
+};
+
+export function activityGlyph(status: EventStatus): string {
+  return STATUS_GLYPHS[status] ?? "?";
+}
+
+// Compact human elapsed time: seconds under a minute, minutes under an hour,
+// hours otherwise.
+export function formatElapsed(ms: number): string {
+  const seconds = Math.max(0, Math.floor(ms / 1000));
+  if (seconds >= 3600) return `${Math.floor(seconds / 3600)}h`;
+  if (seconds >= 60) return `${Math.floor(seconds / 60)}m`;
+  return `${seconds}s`;
+}
+
+// A liveness marker: a filled dot while the event is live, blank otherwise.
+export function livenessMarker(live: boolean): string {
+  return live ? "●" : "·";
+}
+
+// Render one activity card. Collapsed shows a single summary line; expanded adds
+// the bounded detail (with a truncation note when the #306 mapper bounded it).
+export function renderActivityCard(event: PresentedEvent, expanded: boolean): string[] {
+  const summary = event.summary || event.kind;
+  const head = `${activityGlyph(event.status)} ${event.kind} · ${summary} · ${formatElapsed(
+    event.elapsedMs,
+  )} ${livenessMarker(event.live)} ${event.status}`;
+  if (!expanded) return [head];
+  const detail = event.detail === "" ? ["  (no detail)"] : event.detail.split("\n").map((l) => `  ${l}`);
+  const truncated = event.detailTruncated ? ["  … (detail truncated)"] : [];
+  return [head, ...detail, ...truncated];
+}
+
+// The activity view state: which card indices are expanded, whether follow-mode
+// is on (auto-track the latest event), and how many events arrived since the view
+// was last read. Immutable; transitions return new states.
+export interface ActivityViewState {
+  expanded: ReadonlySet<number>;
+  followMode: boolean;
+  unread: number;
+}
+
+export function initialActivityViewState(): ActivityViewState {
+  return { expanded: new Set<number>(), followMode: true, unread: 0 };
+}
+
+// Toggle whether one card index is expanded.
+export function toggleExpand(state: ActivityViewState, index: number): ActivityViewState {
+  const expanded = new Set(state.expanded);
+  if (expanded.has(index)) expanded.delete(index);
+  else expanded.add(index);
+  return { ...state, expanded };
+}
+
+// Expand every card (when count > 0 and not all already expanded) or collapse all
+// otherwise — a simple toggle-all for the panel's expand/collapse gesture.
+export function toggleExpandAll(state: ActivityViewState, count: number): ActivityViewState {
+  const allExpanded = count > 0 && state.expanded.size >= count;
+  const expanded = allExpanded ? new Set<number>() : new Set<number>(Array.from({ length: count }, (_, i) => i));
+  return { ...state, expanded };
+}
+
+export function setFollowMode(state: ActivityViewState, on: boolean): ActivityViewState {
+  return { ...state, followMode: on };
+}
+
+export function markRead(state: ActivityViewState): ActivityViewState {
+  return { ...state, unread: 0 };
+}
+
+export function bumpUnread(state: ActivityViewState, n: number): ActivityViewState {
+  return { ...state, unread: state.unread + Math.max(0, Math.floor(n)) };
+}
+
+// Render the whole activity stream as progressive-disclosure cards (in event
+// order), expanding the cards whose indices are in the view state. Empty stream
+// renders a single placeholder line.
+export function renderActivityStream(
+  events: readonly PresentedEvent[],
+  state: ActivityViewState,
+): string[] {
+  if (events.length === 0) return ["(no activity)"];
+  const lines: string[] = [];
+  events.forEach((event, index) => {
+    lines.push(...renderActivityCard(event, state.expanded.has(index)));
+  });
+  return lines;
+}
+
+// Render the full read-only activity view: a header (counts + follow-mode +
+// unread), the card stream, and a hint line. Pure and deterministic.
+export function formatActivityView(
+  events: readonly PresentedEvent[],
+  state: ActivityViewState,
+): string[] {
+  const active = events.filter((e) => e.live).length;
+  const header =
+    `Activity (read-only) · events ${events.length} · live ${active} · ` +
+    `follow ${state.followMode ? "on" : "off"} · unread ${state.unread}`;
+  return [header, "", ...renderActivityStream(events, state)];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,7 @@ import {
   emptyLifecycleModel,
 } from "./lifecycle-projection.js";
 import { formatLifecycleView } from "./lifecycle-render.js";
+import { formatActivityView, initialActivityViewState } from "./activity-render.js";
 import {
   collectMissionStatusDescriptor,
   formatMissionStatusDescriptor,
@@ -2757,6 +2758,17 @@ program
             description: "Show the mission lifecycle timeline and graph (read-only)",
             action: () => formatLifecycleView(emptyLifecycleModel()).join("\n"),
           },
+          {
+            // Activity view (Issue #307) for the plain readline REPL. The
+            // full-screen shell opens a dedicated overlay for `/activity`; this
+            // action covers the non-full-screen fallback and a palette selection.
+            // It is read-only: it renders the #306 presented event stream as
+            // progressive-disclosure cards. Until a live activity source exists it
+            // renders an empty stream ("no activity"); it never simulates activity.
+            name: "/activity",
+            description: "Show the activity stream as progressive-disclosure cards (read-only)",
+            action: () => formatActivityView([], initialActivityViewState()).join("\n"),
+          },
         ];
 
         // Prefer the stable full-screen conversation shell (regions + fixed
@@ -2794,6 +2806,10 @@ program
             // exists (#319) this supplies an empty model, so the /mission overlay
             // shows "no mission activity" rather than simulated state.
             loadLifecycle: () => emptyLifecycleModel(),
+            // Activity source (Issue #307). Until a live activity source exists
+            // this supplies an empty stream, so the /activity overlay shows "no
+            // activity" rather than simulated activity.
+            loadActivity: () => [],
             settingsPath,
             tools: toolNames,
           });

--- a/src/tui-shell.ts
+++ b/src/tui-shell.ts
@@ -41,6 +41,14 @@ import type { LspView } from "./lsp-runtime.js";
 import { formatLifecycleView } from "./lifecycle-render.js";
 import { emptyLifecycleModel } from "./lifecycle-projection.js";
 import type { LifecycleModel } from "./lifecycle-projection.js";
+import {
+  formatActivityView,
+  initialActivityViewState,
+  toggleExpandAll,
+  setFollowMode,
+} from "./activity-render.js";
+import type { ActivityViewState } from "./activity-render.js";
+import type { PresentedEvent } from "./event-presentation.js";
 import { emptyTaskView, formatTaskView } from "./task-runtime.js";
 import type { TaskView } from "./task-runtime.js";
 import {
@@ -403,8 +411,23 @@ export interface ShellState {
   // mutates the mission it inspects and performs no edits. Optional so pure
   // render callers and tests can omit it.
   lifecycle?: LifecycleModel;
+  // Read-only activity view (Issue #307): the #306 presented event stream
+  // rendered as progressive-disclosure cards, plus the interactive view state
+  // (which cards are expanded, follow-mode, unread). It opens as an overlay over
+  // the main area exactly like the mission lifecycle view; the composer and
+  // status stay anchored. The events are a snapshot from the supplier; the view
+  // state is updated by the panel's key handler. Optional so pure render callers
+  // and tests can omit it.
+  activity?: ActivityOverlay;
   now?: number;
   reducedMotion?: boolean;
+}
+
+// The activity overlay snapshot: the presented event stream plus its interactive
+// view state (Issue #307).
+export interface ActivityOverlay {
+  events: PresentedEvent[];
+  view: ActivityViewState;
 }
 
 export interface GoalRailState {
@@ -1758,6 +1781,47 @@ export function renderLifecyclePanel(
   return clipped;
 }
 
+// Render the read-only activity overlay (Issue #307) — the #306 presented event
+// stream as progressive-disclosure cards. Read-only: it renders the snapshot the
+// supplier returned and performs no edits, exactly like the mission lifecycle
+// panel above. The footer documents the panel's expand/follow gestures.
+export function renderActivityPanel(
+  height: number,
+  cols: number,
+  style: ShellStyle,
+  overlay: ActivityOverlay,
+): string[] {
+  const h = Math.max(0, Math.floor(height));
+  if (h === 0) return [];
+  const w = Math.max(0, Math.floor(cols));
+
+  const head: string[] = [
+    clipVisible(
+      `${style.bold}${style.accent}▤ Activity${style.reset}  ${style.dim}(read-only · no edits performed)${style.reset}`,
+      w,
+    ),
+    renderRule("cards · elapsed · liveness · status", w, style),
+  ];
+
+  const body = formatActivityView(overlay.events, overlay.view).map((line) => clipVisible(line, w));
+
+  const foot: string[] = [
+    "",
+    clipVisible(`${style.dim}e expand/collapse · f follow · Esc close${style.reset}`, w),
+  ];
+
+  const out: string[] = [];
+  const bodyBudget = h - head.length - foot.length;
+  if (bodyBudget <= 0) {
+    out.push(...head.slice(0, h));
+  } else {
+    out.push(...head, ...body.slice(0, bodyBudget), ...foot);
+  }
+  const clipped = out.slice(0, h);
+  while (clipped.length < h) clipped.push("");
+  return clipped;
+}
+
 function renderEmptyTranscript(region: Region, _cols: number, _style: ShellStyle): string[] {
   const height = Math.max(0, region.end - region.start);
   if (height === 0) return [];
@@ -2313,6 +2377,16 @@ export function composeScreen(state: ShellState): ComposedScreen {
     lines.push(
       ...renderLifecyclePanel(layout.composer.start, layout.viewport.cols, style, state.lifecycle),
     );
+  } else if (state.activity) {
+    // The activity view (Issue #307) takes over the main area the same way: a
+    // read-only rendering of the #306 presented event stream as
+    // progressive-disclosure cards, so the transcript underneath is untouched and
+    // closing it returns to the same conversation. An active side question,
+    // stats, language-server, task, or lifecycle view (above) wins so it is never
+    // hidden.
+    lines.push(
+      ...renderActivityPanel(layout.composer.start, layout.viewport.cols, style, state.activity),
+    );
   } else if (state.helpOpen) {
     // Help replaces only the transcript region. Product identity remains visible
     // above it while the composer and status stay anchored below; dismissing the
@@ -2546,6 +2620,11 @@ export interface ConversationShellOptions {
   // supplier reads durable state. Optional so a shell without a mission source
   // still renders (an empty model is used).
   loadLifecycle?: () => LifecycleModel;
+  // Optional supplier of the read-only #306 presented activity stream (Issue
+  // #307) for the /activity overlay. The shell never mutates the run here; the
+  // supplier reads presented events. Optional so a shell without an activity
+  // source still renders (an empty stream is used).
+  loadActivity?: () => PresentedEvent[];
   settingsPath: string;
   tools: readonly string[];
   stdin?: NodeJS.ReadStream;
@@ -3180,6 +3259,48 @@ export function runConversationShell(opts: ConversationShellOptions): Promise<vo
     if (b === 0x1b || b === 0x03 || b === 0x71 || b === 0x3f || b === 0x64) closeLifecycle();
   }
 
+  // Activity view (Issue #307): open a read-only overlay rendering the #306
+  // presented event stream as progressive-disclosure cards. Isolation is
+  // structural — it reads the snapshot the supplier returns (or an empty stream
+  // when there is no activity source yet), never mutates the run, appends to the
+  // transcript, or performs an edit. The view state (expand/collapse, follow-mode)
+  // is interactive and updated by handleActivityKey.
+  function openActivity(): void {
+    const events = opts.loadActivity ? opts.loadActivity() : [];
+    state.activity = { events, view: initialActivityViewState() };
+    scheduleRender();
+  }
+
+  function closeActivity(): void {
+    if (!state.activity) return;
+    state.activity = undefined;
+    scheduleRender();
+  }
+
+  // Route a key while the activity view is open. Modal like the other overlays:
+  // `e` toggles expand/collapse-all, `f` toggles follow-mode, and the dismiss
+  // gestures close; nothing is typed behind it.
+  function handleActivityKey(buf: Buffer): void {
+    if (buf.length !== 1 || !state.activity) return;
+    const b = buf[0];
+    if (b === 0x65) {
+      // 'e' — expand/collapse all cards.
+      const view = toggleExpandAll(state.activity.view, state.activity.events.length);
+      state.activity = { ...state.activity, view };
+      scheduleRender();
+      return;
+    }
+    if (b === 0x66) {
+      // 'f' — toggle follow-mode.
+      const view = setFollowMode(state.activity.view, !state.activity.view.followMode);
+      state.activity = { ...state.activity, view };
+      scheduleRender();
+      return;
+    }
+    // Esc, Ctrl+C, q, ?, d
+    if (b === 0x1b || b === 0x03 || b === 0x71 || b === 0x3f || b === 0x64) closeActivity();
+  }
+
   // Prompt-history recall (criterion 2). This slice keeps the caret at
   // end-of-input (no intra-text cursor movement), so Up/Down recall previous
   // prompts without hijacking cursor movement; the in-progress draft is preserved
@@ -3796,6 +3917,12 @@ export function runConversationShell(opts: ConversationShellOptions): Promise<vo
       openLifecycle();
       return true;
     }
+    if (cmd.name === "/activity") {
+      // Open the in-place read-only activity view (Issue #307) instead of the
+      // plain-REPL fallback action.
+      openActivity();
+      return true;
+    }
     const runtimeOutput = formatRuntimeSlashCommand(cmd.name, {
       model: opts.config.model,
       workspace: opts.workspace.root,
@@ -3914,6 +4041,14 @@ export function runConversationShell(opts: ConversationShellOptions): Promise<vo
     // dismiss gestures act, and nothing is typed behind it.
     if (state.lifecycle) {
       handleLifecycleKey(buf);
+      return;
+    }
+
+    // While the activity view is open it is modal (Issue #307): expand/collapse
+    // (`e`), follow-mode (`f`), and the dismiss gestures act; nothing is typed
+    // behind it.
+    if (state.activity) {
+      handleActivityKey(buf);
       return;
     }
 

--- a/tests/unit/activity-render.test.ts
+++ b/tests/unit/activity-render.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+  activityGlyph,
+  formatElapsed,
+  livenessMarker,
+  renderActivityCard,
+  renderActivityStream,
+  formatActivityView,
+  initialActivityViewState,
+  toggleExpand,
+  toggleExpandAll,
+  setFollowMode,
+  markRead,
+  bumpUnread,
+} from "../../src/activity-render.js";
+import type { PresentedEvent } from "../../src/event-presentation.js";
+import { renderActivityPanel, shellStyle } from "../../src/tui-shell.js";
+
+function event(overrides: Partial<PresentedEvent> = {}): PresentedEvent {
+  return {
+    kind: "tool-call",
+    status: "active",
+    summary: "running rg",
+    detail: "line1\nline2",
+    detailTruncated: false,
+    elapsedMs: 1500,
+    live: true,
+    ...overrides,
+  };
+}
+
+describe("activity glyphs / elapsed / liveness", () => {
+  it("maps each status to a stable glyph", () => {
+    expect(activityGlyph("pending")).toBe("○");
+    expect(activityGlyph("active")).toBe("◆");
+    expect(activityGlyph("completed")).toBe("✓");
+    expect(activityGlyph("failed")).toBe("✕");
+    expect(activityGlyph("waiting")).toBe("◇");
+    expect(activityGlyph("cancelled")).toBe("⊘");
+  });
+
+  it("formats elapsed time as s/m/h", () => {
+    expect(formatElapsed(1500)).toBe("1s");
+    expect(formatElapsed(90_000)).toBe("1m");
+    expect(formatElapsed(7_200_000)).toBe("2h");
+  });
+
+  it("marks liveness", () => {
+    expect(livenessMarker(true)).toBe("●");
+    expect(livenessMarker(false)).toBe("·");
+  });
+});
+
+describe("renderActivityCard: progressive disclosure", () => {
+  it("renders a single summary line when collapsed", () => {
+    const lines = renderActivityCard(event(), false);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain("◆ tool-call");
+    expect(lines[0]).toContain("running rg");
+    expect(lines[0]).toContain("1s");
+    expect(lines[0]).toContain("●");
+    expect(lines[0]).toContain("active");
+  });
+
+  it("reveals bounded detail when expanded", () => {
+    const lines = renderActivityCard(event(), true);
+    expect(lines[0]).toContain("running rg");
+    expect(lines).toContain("  line1");
+    expect(lines).toContain("  line2");
+  });
+
+  it("notes truncation when the detail was bounded", () => {
+    const lines = renderActivityCard(event({ detailTruncated: true }), true);
+    expect(lines).toContain("  … (detail truncated)");
+  });
+
+  it("shows a placeholder for empty detail when expanded", () => {
+    const lines = renderActivityCard(event({ detail: "" }), true);
+    expect(lines).toContain("  (no detail)");
+  });
+});
+
+describe("renderActivityStream / formatActivityView", () => {
+  it("renders a placeholder for an empty stream", () => {
+    expect(renderActivityStream([], initialActivityViewState())).toEqual(["(no activity)"]);
+  });
+
+  it("renders one card per event, expanding only the expanded indices", () => {
+    const events = [event({ summary: "first" }), event({ summary: "second" })];
+    const state = toggleExpand(initialActivityViewState(), 1);
+    const lines = renderActivityStream(events, state);
+    expect(lines.some((l) => l.includes("first"))).toBe(true);
+    // The expanded second card reveals its detail; the collapsed first does not.
+    expect(lines.filter((l) => l.includes("line1")).length).toBe(1);
+  });
+
+  it("renders the view header with counts, follow-mode, and unread", () => {
+    const events = [event({ live: true }), event({ live: false, status: "completed" })];
+    const view = formatActivityView(events, initialActivityViewState());
+    expect(view[0]).toContain("events 2");
+    expect(view[0]).toContain("live 1");
+    expect(view[0]).toContain("follow on");
+    expect(view[0]).toContain("unread 0");
+  });
+});
+
+describe("activity view-state transitions", () => {
+  it("starts with no expansion, follow-mode on, zero unread", () => {
+    const state = initialActivityViewState();
+    expect(state.expanded.size).toBe(0);
+    expect(state.followMode).toBe(true);
+    expect(state.unread).toBe(0);
+  });
+
+  it("toggleExpand adds and removes an index without mutating the input", () => {
+    const s0 = initialActivityViewState();
+    const s1 = toggleExpand(s0, 2);
+    expect(s1.expanded.has(2)).toBe(true);
+    expect(s0.expanded.has(2)).toBe(false);
+    const s2 = toggleExpand(s1, 2);
+    expect(s2.expanded.has(2)).toBe(false);
+  });
+
+  it("toggleExpandAll expands all then collapses all", () => {
+    const s0 = initialActivityViewState();
+    const expanded = toggleExpandAll(s0, 3);
+    expect(expanded.expanded.size).toBe(3);
+    const collapsed = toggleExpandAll(expanded, 3);
+    expect(collapsed.expanded.size).toBe(0);
+  });
+
+  it("setFollowMode / markRead / bumpUnread behave purely", () => {
+    const s0 = initialActivityViewState();
+    expect(setFollowMode(s0, false).followMode).toBe(false);
+    expect(bumpUnread(s0, 4).unread).toBe(4);
+    expect(markRead(bumpUnread(s0, 4)).unread).toBe(0);
+    expect(s0.unread).toBe(0); // input unchanged
+  });
+});
+
+describe("renderActivityPanel (TUI render against fixture events)", () => {
+  const style = shellStyle("none");
+
+  it("renders the panel header, cards, and footer gestures", () => {
+    const overlay = { events: [event({ summary: "running rg" })], view: initialActivityViewState() };
+    const lines = renderActivityPanel(12, 60, style, overlay);
+    expect(lines.length).toBe(12);
+    const joined = lines.join("\n");
+    expect(joined).toContain("Activity");
+    expect(joined).toContain("read-only");
+    expect(joined).toContain("running rg");
+    expect(joined).toContain("e expand/collapse · f follow · Esc close");
+  });
+
+  it("shows the empty placeholder for an empty stream", () => {
+    const overlay = { events: [], view: initialActivityViewState() };
+    expect(renderActivityPanel(10, 60, style, overlay).join("\n")).toContain("(no activity)");
+  });
+
+  it("returns no lines for a zero-height region", () => {
+    const overlay = { events: [event()], view: initialActivityViewState() };
+    expect(renderActivityPanel(0, 60, style, overlay)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the read-only activity view to the TUI (#307, the activity-rendering child of #291). A pure `activity-render` module renders the #306 presented event stream as progressive-disclosure cards: each card shows a status glyph, kind, summary, elapsed time, and a liveness marker, and expands to reveal bounded detail (with a truncation note). A small immutable view state tracks which cards are expanded, follow-mode, and an unread count, with pure transitions (`toggleExpand`, `toggleExpandAll`, `setFollowMode`, `markRead`, `bumpUnread`). It is wired into the TUI as an `/activity` overlay panel following the #314 `/mission` pattern (`ShellState.activity`, `renderActivityPanel`, modal key handling with `e` expand/collapse-all and `f` follow-mode, a `composeScreen` branch, the `/activity` slash command, and a `loadActivity` supplier). The panel renders a loader-provided event stream and shows "no activity" for an empty stream — it never simulates activity; a live source arrives later. Color degrades to glyphs + plain text under reduced-color/no-color. Tests pin the rendering and view-state transitions (cards, stream, view, transitions, and the TUI panel against fixture events).

This continues #291, depends on #306, and feeds #318 (Desktop canvas) and #319 (evidence-bound capstone).

## Verification

- `npm run typecheck`
- `npm run build`
- `npm test` — 102 files, 1929 tests passed (incl. 17 new `activity-render` tests, including TUI `renderActivityPanel` render tests against fixture events); no regressions from the `tui-shell.ts` integration
- `npm run smoke` — 4 files, 54 tests passed
- Exact-head terminal E2E at `2996adf27236e75765221f03f5a526900f12a606` (executing the built `dist/` rendering code):
  - collapsed → `✓ tool-call · read package.json · 0s · completed`, `◆ tool-call · running vitest · 5s ● active`, `◇ approval · approve npm publish · 1s · waiting`
  - expanding card 1 reveals its bounded detail (`PASS unit` / `1929 tests`) — progressive disclosure
  - `renderActivityPanel(14, 64, …)` → panel header + cards + `e expand/collapse · f follow · Esc close` footer, exit 0
- A live interactive tmux TUI session was not run (the TUI requires a TTY + live provider); the TUI rendering and view-state transitions are verified at the unit/render level (`renderActivityPanel` against fixture events), consistent with how the existing TUI panels are tested. Fine-grained copy and reading-position-during-streaming build on the existing transcript scroll infrastructure (#163/#164).
- Pre-existing environmental note: three integration tests (provider/tool invocation output-capping and session-summary) fail identically on a clean `origin/main` checkout on this macOS host; they are unrelated to this change and pass in Linux CI.

Closes #307
