### PR TITLE
fix(governance): support runner comment pagination

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -113,9 +113,9 @@ jobs:
             gh issue edit "$ISSUE_NUMBER" --repo "$REPOSITORY" --add-label "$label"
           done < <(jq -r '.addLabels[]' "$RUNNER_TEMP/plan.json")
 
-          comment_id="$(gh api --paginate --slurp \
+          comment_id="$(gh api --paginate \
             "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" \
-            --jq 'flatten | map(select(.user.login == "github-actions[bot]" and (.body | contains("<!-- oh-my-cli:auto-triage:v1 -->")))) | first | .id // empty')"
+            | jq -s -r 'flatten | map(select(.user.login == "github-actions[bot]" and (.body | contains("<!-- oh-my-cli:auto-triage:v1 -->")))) | first | .id // empty')"
           jq -n --rawfile body "$RUNNER_TEMP/comment.md" '{body: $body}' > "$RUNNER_TEMP/comment.json"
 
           if [[ -n "$comment_id" ]]; then


### PR DESCRIPTION
## Summary

Fixes the post-merge Issue triage dogfood failure observed in run 30798739587. The GitHub CLI version on the hosted runner rejects combining paginated slurp mode with its built-in JSON query flag, so the workflow now streams every page into the standalone JSON processor and performs the same full-page lookup there.

This preserves the intended idempotency without truncating comments or introducing a pipe that exits before pagination completes.

## Reviewer Test Plan

- Run automatic triage for an Issue with no prior automated summary and confirm one summary is created.
- Run it again for the same Issue and confirm the existing summary is updated rather than duplicated.
- Confirm comment lookup works when comments span multiple API pages.

## Validation

- Reproduced the exact failure from the hosted runner log.
- Executed the replacement lookup against Issue #500 under `pipefail`; it completed successfully.
- Workflow formatting, static validation, and diff checks passed.

Refs #498
