### PR TITLE
fix(cli): surrogate-safe truncation for repo-context file/dir names (Issue #876)

### DIFF
--- a/src/repo-context.ts
+++ b/src/repo-context.ts
@@ -117,7 +117,10 @@ function redact(text: string): string {
 }
 
 function redactName(text: string): string {
-  return redactSecrets(text).text.slice(0, MAX_NAME_LEN);
+  const t = redactSecrets(text).text;
+  // Issue #876: safeCutEnd drops an astral char straddling the bound whole
+  // rather than orphaning a surrogate.
+  return t.slice(0, safeCutEnd(t, MAX_NAME_LEN));
 }
 
 function redactCommand(text: string): string {

--- a/tests/unit/repo-context.test.ts
+++ b/tests/unit/repo-context.test.ts
@@ -239,6 +239,25 @@ describe("structure outline", () => {
     expect(snap.structure.length).toBe(200);
     expect(snap.structureOverflow).toBe(5);
   });
+
+  it("does not orphan a surrogate when truncating a structure name (Issue #876)", () => {
+    const dir = tmp();
+    // 199 ASCII chars + an astral character (2 UTF-16 units) straddles MAX_NAME_LEN=200.
+    write(dir, "a".repeat(199) + "🚀tail", "");
+    const snap = collectRepoContext({ workspace: dir });
+    const LONE = /[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/;
+    expect(snap.structure).toHaveLength(1);
+    expect(snap.structure[0].name).not.toMatch(LONE);
+    expect(snap.structure[0].name.length).toBeLessThanOrEqual(200);
+  });
+
+  it("keeps in-range names, including emoji, unchanged (Issue #876)", () => {
+    const dir = tmp();
+    write(dir, "README.md", "");
+    write(dir, "🚀notes.md", "");
+    const snap = collectRepoContext({ workspace: dir });
+    expect(snap.structure.map((e) => e.name)).toEqual(["README.md", "🚀notes.md"]);
+  });
 });
 
 describe("VCS state", () => {


### PR DESCRIPTION
Closes #876

## Summary
- Route `redactName` through `safeCutEnd` so an astral character straddling the 200-char bound is dropped whole instead of leaving an unpaired surrogate in repo-context snapshot names.
- Add red→green regression tests in `tests/unit/repo-context.test.ts` for the straddling name and in-range emoji passthrough.

## Test plan
- [x] Reverting the cut to raw `slice` fails the new surrogate test; restoring `safeCutEnd` turns it green
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (unit: 4161 passed)
- [x] `npx vitest run tests/integration` (953 passed; 3 local env failures unrelated to this change)
- [x] `npm run smoke` (54 passed)
- [x] `npm audit --omit=dev --audit-level=high` (0)